### PR TITLE
Configuration edits

### DIFF
--- a/accounts/include/style.css
+++ b/accounts/include/style.css
@@ -67,8 +67,26 @@ margin-right: 10px;
 margin-top: 11px;
 }
 
+#config-error-alert {
+	position:fixed;
+	right:10px;
+	bottom:10px;
+	min-width:300px;
+}
+
+#config-error-alert .btn{
+	float:right;
+	margin-top:16px;
+}	
+
 #login-form {
             margin-left: 38%;
+}
+
+.form-wrapper{
+	margin:auto;
+	max-width:400px;
+	line-height:1.5;
 }
 
 .responsive-image { 

--- a/config-edit.php
+++ b/config-edit.php
@@ -1,0 +1,126 @@
+<?php
+/*                    C O N F I G - E D I T . P H P
+ * BRL-CAD
+ *
+ * Copyright (c) 1995-2013 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this file; see the file named COPYING for more
+ * information.
+ */
+/** @file geometry_viewer/config-edit.php
+ *
+ */
+	require_once('accounts/auth.php');
+	require_once('config.php');
+	include_once('header.php');
+?>
+	
+	<!-- TODO: Make this style find a place in stylesheets -->
+	<style> body { overflow:auto; } </style>
+
+	<div class="form-wrapper">
+        <form role="form" action="config-process.php" method="post">
+			<h2> Configuration Settings </h2>
+
+			<!-- The title of the app, appears in header and at many other places --> 	
+			<div class="form-group">
+				<label for="app-title">App Title</label>
+				<input type="text" class="form-control" name="app-title" value="<?php echo $title; ?>">	
+			</div>		
+			
+			<!-- The url of the app -->
+			<div class="form-group">
+				<label for="app-url">App URL</label>
+				<input type="text" class="form-control" name="app-url" value="<?php echo $siteUrl; ?>">
+			</div>
+			
+			<!-- Path to mged -->
+			<div class="form-group">
+				<label for="mged-path">mged Path</label>
+				<input type="text" class="form-control" name="mged-path" value="<?php echo $mgedPath; ?>">
+				<p class="help-block"> 
+					To know your mged path, go to terminal and check the output of command <code>which mged</code>
+				</p>               
+			</div>
+
+			<!-- Path to g-obj -->
+			<div class="form-group">
+				<label for="gobj-path">gobj Path</label>
+				<input type="text" class="form-control" name="gobj-path" value="<?php echo $gobjPath; ?>">
+				<p class="help-block"> 
+					To know your g-obj path, go to terminal and check the output of command <code>which g-obj</code>
+				</p>
+			</div>
+			
+			<!-- MySQL Credentials -->
+			<div class="form-group">
+				<label for="mysql-username">MySQL Username</label>
+				<input type="text" class="form-control" name="mysql-username" value="<?php echo $mysqlUsername; ?>">
+			</div>		
+			
+			<div class="form-group">
+				<label for="mysql-password">MySQL Password</label>
+				<input type="password" class="form-control" name="mysql-password" value="<?php echo $mysqlPassword; ?>">
+			</div>
+
+			<div class="form-group">
+				<label for="mysql-database">MySQL Database</label>
+				<input type="text" class="form-control" name="mysql-database" value="<?php echo $mysqlDatabase; ?>">
+			</div>
+			
+			<!-- Subject of the sign-up and password reset confirmation mail -->
+			<div class="form-group">
+				<label for="new-account-subject">New Account Mail Subject</label>
+				<input type="text" class="form-control" name="new-account-subject" value="<?php echo $newAccountSubject; ?>">
+				<p class="help-block"> 
+					After sign up user will recieve a confirmation mail with subject that you specify here.
+				</p>
+			</div>
+			
+			<div class="form-group">
+				<label for="password-reset-subject">Password Reset Subject</label>
+				<input type="text" class="form-control" name="password-reset-subject" value="<?php echo $passwordResetSubject; ?>">
+				<p class="help-block"> 
+					For resetting the password user will recieve a mail with subject that you specify here.
+				</p>
+			</div>
+			
+			<!-- Email address of the sender -->
+			<div class="form-group">
+				<label for="sender-email">Sender e-mail </label>
+				<input type="email" class="form-control" name="sender-email" value="<?php echo $senderEmail; ?>">
+				<p class="help-block"> 
+					Currently, it should be a gmail address.  
+				</p>             
+			</div>
+
+			<!-- Name of the sender -->
+			<div class="form-group">
+				<label for="sender-name">Sender Name </label>
+				<input type="text" class="form-control" name="sender-name" value="<?php echo $senderName; ?>">
+			</div>
+			
+			<!-- Password for email account -->
+			<div class="form-group">
+				<label for="sender-password">Sender e-mail's password </label>
+				<input type="password" class="form-control" name="sender-password" value="<?php echo $senderPassword; ?>">
+			</div>
+		
+			<button type="submit" class="btn btn-primary" name="submit">Submit</button>
+		</form>  
+	</div>
+      
+</body>
+</html>
+

--- a/config-process.php
+++ b/config-process.php
@@ -1,0 +1,147 @@
+
+<?php
+/*                C O N F I G - P R O C E S S . P H P
+ * BRL-CAD
+ *
+ * Copyright (c) 1995-2013 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this file; see the file named COPYING for more
+ * information.
+ */
+/** @file geometry_viewer/config-edit.php
+ *
+ */
+	require_once('accounts/auth.php');
+	include_once('header.php');
+?>
+	
+	<!-- TODO: Make this style find a place in stylesheets -->
+	<style> body { overflow:auto; } </style>
+
+<?php	
+	if(isset ($_POST['submit'])) {	
+	
+		$configString = <<<EOT
+		
+/*                     C O N F I G . P H P
+ * BRL-CAD
+ *
+ * Copyright (c) 1995-2013 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this file; see the file named COPYING for more
+ * information.
+ */
+/** @file geometry_viewer/config.php
+ *
+ */
+
+    /** Title of project. */
+    \$title = "{$_POST['app-title']}";
+
+	
+    /** Domain name of site. e.g. http://brlcad.org/ */
+    \$siteUrl = "{$_POST['app-url']}";
+	
+    /** 
+     * Path of mged executable file. To check this path on your 
+     * system, run this command on terminal: "which mged" 
+     * (without quotes).
+     */
+    \$mgedPath = "{$_POST['mged-path']}";
+
+	
+    /**
+     * Path of g-obj executable file. To check this path on your 
+     * system, run this command on terminal: "which g-obj" 
+     * (without quotes).
+     */
+    \$gobjPath = "{$_POST['gobj-path']}";
+
+
+    /** MySQL credentials. */
+    \$mysqlUsername = "{$_POST['mysql-username']}";
+    \$mysqlPassword = "{$_POST['mysql-password']}";
+    \$mysqlDatabase = "{$_POST['mysql-database']}";
+			
+    /** Subject of confirmation e-mail sent on new account creation. */
+    \$newAccountSubject = "{$_POST['new-account-subject']}";
+
+    /** Subject of password reset e-mail. */
+    \$passwordResetSubject = "{$_POST['password-reset-subject']}";
+		
+    /** E-mail address of sender. Currently, it should be gmail address. */
+    \$senderEmail = "{$_POST['sender-email']}";
+	
+    /** Name of sender written in emails. */
+    \$senderName = "{$_POST['sender-name']}";
+		
+    /** Password of sender's account. */
+    \$senderPassword = "{$_POST['sender-password']}";
+	
+    \$normTol = '10';	
+	
+    require_once('config-validate.php');
+
+/*                                                                    
+ * Local Variables:                                                   
+ * mode: PHP                                                            
+ * tab-width: 8
+ * End:                                                               
+ * ex: shiftwidth=4 tabstop=8                                         
+ */
+
+EOT;
+
+        /** Open config.php file and write the configurations to it */
+        $configFile = fopen("config.php","w") or die 
+            ('<div class="alert alert-danger"> Sorry, we were not able to open this file. 
+	    You will have to copy paste the following content yourself in config.php. 
+	    Don\'t forget to delete the prior content if any. </div> <pre> &lt;?PHP'.$configString.'?&gt; </pre>');
+        fwrite($configFile, '<?php'.$configString.'?>');
+        fclose($configFile);
+    }
+
+    /** Include config.php file again to check for validations */
+    require_once('config.php');
+
+    /** If configuration errors still presist */
+    if(!empty($errorArray)){
+        header('Location:config-edit.php');
+    }
+?>
+
+	<div class="alert alert-success"> 
+		Your new config file has been created! 
+		<a href="upload.php" class="btn btn-success"> Upload a Model </a>
+	</div>
+<?php
+ /*                                                                    
+ * Local Variables:                                                   
+ * mode: PHP                                                            
+ * tab-width: 8
+ * End:                                                               
+ * ex: shiftwidth=4 tabstop=8                                         
+ */
+?>

--- a/config-validate.php
+++ b/config-validate.php
@@ -1,0 +1,61 @@
+<?
+/*             C O N F I G - V A L I D A T E . P H P
+ * BRL-CAD
+ *
+ * Copyright (c) 1995-2013 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this file; see the file named COPYING for more
+ * information.
+ */
+/** @file geometry_viewer/config-validate.php
+ *
+ */
+
+    /** Array of errors */
+    $errorArray = array();
+	
+    /** If mged path is empty or the file does not exist at path specified, 
+    give an error **/	
+    if (($mgedPath == '') || (!file_exists($mgedPath))) {
+        $errorArray[] = 'Your path to mged is either empty or wrong';
+    }
+
+    /** If gobj path is empty or the file does not exist at path specified,
+    give an error **/
+    if (($gobjPath == '') || (!file_exists($gobjPath))) {
+        $errorArray[] = 'Your path to g-obj is either empty or wrong';
+    } 
+
+    /** If there are any errors in configuration files, show them */
+    if (!empty($errorArray) && isset($username)) { ?>
+        <div class="alert alert-danger" id="config-error-alert">
+            <p> Your configuration file has following errors: "
+                 
+	    <?php foreach ($errorArray as $error) {
+                echo '<p>'.$error.'</p>';
+            } ?>
+                
+    	    <a href=<?php echo $siteUrl.'/geometry_viewer/config-edit.php'; ?> class="btn btn-danger">
+                Edit Configuration      
+            </a>
+        </div>
+    <?php } 
+/*                                                                    
+ * Local Variables:                                                   
+ * mode: PHP                                                            
+ * tab-width: 8
+ * End:                                                               
+ * ex: shiftwidth=4 tabstop=8                                         
+ */
+?>

--- a/config.php
+++ b/config.php
@@ -1,4 +1,4 @@
-<?php
+<?php		
 /*                     C O N F I G . P H P
  * BRL-CAD
  *
@@ -25,46 +25,49 @@
     /** Title of project. */
     $title = "BRL-CAD Online Geometry Viewer";
 
+	
     /** Domain name of site. e.g. http://brlcad.org/ */
-    $siteUrl = 'http://localhost/~harmanpreet/';
-
-    /** Subject of confirmation e-mail sent on new account creation. */
-    $newAccountSubject = 'Confirmation Link';
-
-    /** Subject of password reset e-mail. */
-    $passwordResetSubject = 'Reset Password';
-
-    /** E-mail address of sender. Currently, it should be gmail address. */
-    $senderEmail = 'yourGmailAccount@gmail.com';
-
-    /** Password of sender's account. */
-    $senderPassword = 'xxxxxxxx';
-
-    /** Name of sender written in emails. */
-    $senderName = 'Online Geometry Viewer';
-
+    $siteUrl = "http://localhost/";
+	
     /** 
      * Path of mged executable file. To check this path on your 
      * system, run this command on terminal: "which mged" 
      * (without quotes).
      */
-    $mgedPath = 'env /usr/brlcad/dev-7.24.1/bin/mged';
+    $mgedPath = "/usr/brlcad/bin/mged";
 
+	
     /**
      * Path of g-obj executable file. To check this path on your 
      * system, run this command on terminal: "which g-obj" 
      * (without quotes).
      */
-    $gobjPath = '/usr/brlcad/dev-7.24.1/bin/g-obj';
-
-    $normTol = '10';
+    $gobjPath = "/usr/brlcad/bin/g-obj";
 
 
     /** MySQL credentials. */
+    $mysqlUsername = " ";
+    $mysqlPassword = " ";
+    $mysqlDatabase = " ";
+			
+    /** Subject of confirmation e-mail sent on new account creation. */
+    $newAccountSubject = "Confirmation Link";
 
-    $mysqlUsername = '';
-    $mysqlPassword = '';
-    $mysqlDatabase = '';
+    /** Subject of password reset e-mail. */
+    $passwordResetSubject = "Reset Passwords";
+		
+    /** E-mail address of sender. Currently, it should be gmail address. */
+    $senderEmail = "yourGmailAccount@gmail.com";
+	
+    /** Name of sender written in emails. */
+    $senderName = "Your Sender Name";
+		
+    /** Password of sender's account. */
+    $senderPassword = "XXXXX";
+	
+    $normTol = '10';	
+	
+    require_once('config-validate.php');
 
 /*                                                                    
  * Local Variables:                                                   

--- a/upload.php
+++ b/upload.php
@@ -22,6 +22,7 @@
  *
  */
     include 'accounts/auth.php';
+	include_once('config.php');
 //    include 'variables.php';
 ?>
 

--- a/upload_file.php
+++ b/upload_file.php
@@ -65,7 +65,7 @@
      * Command that lists the entities of a BRL-CAD database file is 
      * copied into a variable. 
      */
-    $cmd = "$mgedPath -c $uploadPath/$dbFileName ls -a 2>&1";
+    $cmd = "env $mgedPath -c $uploadPath/$dbFileName ls -a 2>&1";
 
     /** Output of command is stored into variable as string. */
     $out = shell_exec($cmd);


### PR DESCRIPTION
When I installed OGV, it din't show any models. In a quick inspection I found out that the path to mged and obj were hard coded in the config file, which were different than what I had on my machine. It din't gave much of an error, except a half gibberish looking error on `model_display.php` and there was definitely no cue on how to solve this for the user.

Also, in to do list there was a desire to have users edit configuration file from the browser itself. So I added 
- `config-edit.php` and `config-process.php` that will create the `config.php` file itself and if it's unable to create file then it will give a simple copy paste solution to user.
- `config-validate.php` that will validate the variables whose validity is crucial for the whole app, thus giving an error notification on each page to correct the errors. (Just like we have update notifications in wordpress).

I have edited `upload.php`, so that we can get error notification there too, and then edit stylesheet to give styles to the form that edits configuration and error messages.

I also had to (with heavy heart) add an inline style in `config-edit.php` , because body was `overflow:hidden` in the original styles, changing that would have made a mess to other pages and we have no classes for the body so I had to add a `overflow:auto` inline overriding the styles in style.css. I will keep the larger task of code clean up and CSS clean up for another pull request. 

Then I have removed `env` from $mgedPath, as it's not the path to mged, and as currently the path is entered by user, so it may be confusing if we make user add env. I have concatenated `env` to `$cmd`
